### PR TITLE
feat: add abandonAudioFocus() API (QAP-4557)

### DIFF
--- a/android/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/android/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -261,6 +261,21 @@ abstract class BaseAudioPlayer internal constructor(
     }
 
     /**
+     * Abandons audio focus so other apps can restore their volume.
+     * Uses ExoPlayer's setAudioAttributes toggle when handleAudioFocus is true,
+     * otherwise uses the custom FocusManager.
+     */
+    fun abandonAudioFocus() {
+        if (options.handleAudioFocus) {
+            val attrs = exoPlayer.audioAttributes
+            exoPlayer.setAudioAttributes(attrs, false)
+            exoPlayer.setAudioAttributes(attrs, true)
+        } else {
+            focusManager.abandonAudioFocusIfHeld()
+        }
+    }
+
+    /**
      * Stops and destroys the player. Only call this when you are finished using the player, otherwise use [pause].
      */
     @CallSuper

--- a/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
@@ -556,6 +556,12 @@ class MusicModule(reactContext: ReactApplicationContext) : NativeTrackPlayerSpec
         callback.resolve(null)
     }
 
+    override fun abandonAudioFocus(callback: Promise) = launchInScope {
+        if (verifyServiceBoundOrReject(callback)) return@launchInScope
+        musicService.abandonAudioFocus()
+        callback.resolve(null)
+    }
+
     override fun validateOnStartCommandIntent(callback: Promise) = launchInScope {
         if (verifyServiceBoundOrReject(callback)) return@launchInScope
         callback.resolve(musicService.onStartCommandIntentValid)

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -78,6 +78,11 @@ class MusicService : HeadlessJsMediaService() {
         sWakeLock?.release()
     }
 
+    @MainThread
+    fun abandonAudioFocus() {
+        player.abandonAudioFocus()
+    }
+
     fun getBitmapLoader(): BitmapLoader {
         return mediaSession.bitmapLoader
     }

--- a/ios/TrackPlayer.mm
+++ b/ios/TrackPlayer.mm
@@ -199,6 +199,9 @@ RCT_EXPORT_MODULE()
 - (void)abandonWakeLock:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject {
   resolve(nil);
 }
+- (void)abandonAudioFocus:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject {
+  resolve(nil);
+}
 - (void)acquireWakeLock:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject {
   resolve(nil);
 }

--- a/src/NativeTrackPlayer.ts
+++ b/src/NativeTrackPlayer.ts
@@ -99,6 +99,7 @@ export interface Spec extends TurboModule {
   // android methods
   acquireWakeLock(): Promise<void>;
   abandonWakeLock(): Promise<void>;
+  abandonAudioFocus(): Promise<void>;
   validateOnStartCommandIntent(): Promise<boolean>;
 }
 

--- a/src/trackPlayer.ts
+++ b/src/trackPlayer.ts
@@ -447,6 +447,14 @@ export async function abandonWakeLock() {
 }
 
 /**
+ * Abandons audio focus so other apps can restore their volume (android only.)
+ */
+export async function abandonAudioFocus(): Promise<void> {
+  if (!isAndroid) return;
+  return TrackPlayer.abandonAudioFocus();
+}
+
+/**
  * get onStartCommandIntent is null or not (Android only.). this is used to identify
  * if musicservice is restarted or not.
  */


### PR DESCRIPTION
## Summary
- Add `abandonAudioFocus()` method to explicitly release audio focus on Android
- When coaching audio is paused/stopped, other apps (YouTube Music, etc.) can immediately restore their volume
- Uses ExoPlayer's `setAudioAttributes` toggle for `handleAudioFocus=true` mode, and custom `FocusManager.abandonAudioFocusIfHeld()` otherwise
- iOS: no-op (resolve nil)

## Changed Files
1. `src/NativeTrackPlayer.ts` - TurboModule spec
2. `src/trackPlayer.ts` - JS API function
3. `BaseAudioPlayer.kt` - Core implementation
4. `MusicService.kt` - Service wrapper
5. `MusicModule.kt` - Bridge method
6. `TrackPlayer.mm` - iOS no-op

## Test plan
- [ ] YouTube Music 재생 → 코칭 시작 (ducking 확인) → 일시정지 → 볼륨 복원 확인
- [ ] 재개 → 다시 ducking 확인
- [ ] 빠른 일시정지/재개 반복 → 크래시 없이 동작
- [ ] iOS 리그레션 확인